### PR TITLE
Make opening of target file more readable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use compress_tools::{ArchiveContents, ArchiveIterator};
 use nix::sys::signal::{signal, SigHandler, Signal};
 use nix::unistd::isatty;
 use regex::RegexSet;
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::io::{self, Read, Seek, Write};
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
@@ -145,7 +145,7 @@ where
                             cur_file = file;
 
                             let filename = cur_file.rsplit('/').next().unwrap();
-                            let extract_file = OpenOptions::new()
+                            let extract_file = File::options()
                                 .write(true)
                                 .create(true)
                                 .truncate(true)


### PR DESCRIPTION
Rust 1.58 stabilizes [`File::options()`](https://doc.rust-lang.org/std/fs/struct.File.html#method.options), which is clearer than OpenOptions and avoids a import.