### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["morganamilo <morganamilo@archlinux.org>"]
 edition = "2021"
 
 description = "Print pacman package files"
-repository = "http://github.com/Morganamilo/paccat"
+repository = "https://github.com/Morganamilo/paccat"
 license = "GPL-3.0"
 keywords = ["archlinux", "arch", "alpm", "pacman"]
 include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97